### PR TITLE
Extra params

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # A Java based OAuth Agent for Financial Grade SPAs
 
-[![Quality](https://img.shields.io/badge/quality-experiment-red)](https://curity.io/resources/code-examples/status/)
+[![Quality](https://img.shields.io/badge/quality-test-yellow)](https://curity.io/resources/code-examples/status/)
 [![Availability](https://img.shields.io/badge/availability-source-blue)](https://curity.io/resources/code-examples/status/)
 
 ## Overview

--- a/doc/Architecture.md
+++ b/doc/Architecture.md
@@ -38,6 +38,24 @@ Response:
 }
 ```
 
+If required, the SPA can POST an object with an extra params field containing runtime OpenID Connect parameters.\
+They key and value of each item must be strings and they will then be appended to the request URL.
+
+```json
+{
+  "extraParams": [
+      {
+          "key": "max-age",
+          "value": "3600",
+      },
+      {
+          "key": "ui_locales",
+          "value": "fr",
+      },
+  ]
+}
+```
+
 ### POST `/login/end`
 
 This endpoint should be be called by the SPA on any page load. The SPA sends the current URL to the OAuth Agent, which can either finish the authorization flow (if it was a response from the Authorization Server), or inform the SPA whether the user is logged in or not (basing on the presence of secure cookies).

--- a/src/main/kotlin/io/curity/oauthagent/AuthorizationServerClient.kt
+++ b/src/main/kotlin/io/curity/oauthagent/AuthorizationServerClient.kt
@@ -2,7 +2,7 @@ package io.curity.oauthagent
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.curity.oauthagent.controller.StartAuthorizationRequest
+import io.curity.oauthagent.controller.StartAuthorizationParameters
 import io.curity.oauthagent.exception.AuthorizationServerException
 import io.curity.oauthagent.exception.InvalidRequestException
 import io.curity.oauthagent.exception.InvalidStateException
@@ -16,8 +16,6 @@ import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientRequestException
 import org.springframework.web.reactive.function.client.awaitBody
 import org.springframework.web.reactive.function.client.awaitExchange
-import java.lang.RuntimeException
-import java.util.*
 
 @Service
 class AuthorizationServerClient(
@@ -150,7 +148,7 @@ class AuthorizationServerClient(
         return cookiesList
     }
 
-    suspend fun getAuthorizationRequestObjectUri(state: String, codeVerifier: String, options: StartAuthorizationRequest?
+    suspend fun getAuthorizationRequestObjectUri(state: String, codeVerifier: String, parameters: StartAuthorizationParameters?
     ): String
     {
         var body =
@@ -161,7 +159,7 @@ class AuthorizationServerClient(
             body += "&scope=${config.scope}"
         }
 
-        options?.extraParams?.forEach {
+        parameters?.extraParams?.forEach {
             body += "&${it.key}=${it.value}"
         }
 

--- a/src/main/kotlin/io/curity/oauthagent/AuthorizationServerClient.kt
+++ b/src/main/kotlin/io/curity/oauthagent/AuthorizationServerClient.kt
@@ -2,6 +2,7 @@ package io.curity.oauthagent
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
+import io.curity.oauthagent.controller.StartAuthorizationRequest
 import io.curity.oauthagent.exception.AuthorizationServerException
 import io.curity.oauthagent.exception.InvalidRequestException
 import io.curity.oauthagent.exception.InvalidStateException
@@ -16,6 +17,7 @@ import org.springframework.web.reactive.function.client.WebClientRequestExceptio
 import org.springframework.web.reactive.function.client.awaitBody
 import org.springframework.web.reactive.function.client.awaitExchange
 import java.lang.RuntimeException
+import java.util.*
 
 @Service
 class AuthorizationServerClient(
@@ -148,7 +150,8 @@ class AuthorizationServerClient(
         return cookiesList
     }
 
-    suspend fun getAuthorizationRequestObjectUri(state: String, codeVerifier: String): String
+    suspend fun getAuthorizationRequestObjectUri(state: String, codeVerifier: String, options: StartAuthorizationRequest?
+    ): String
     {
         var body =
             "client_id=${config.clientID}&state=${state}&response_mode=jwt&response_type=code&redirect_uri=${config.redirectUri}&code_challenge=${codeVerifier.hash()}&code_challenge_method=S256"
@@ -156,6 +159,10 @@ class AuthorizationServerClient(
         if (config.scope != null)
         {
             body += "&scope=${config.scope}"
+        }
+
+        options?.extraParams?.forEach {
+            body += "&${it.key}=${it.value}"
         }
 
         try

--- a/src/main/kotlin/io/curity/oauthagent/CookieEncrypter.kt
+++ b/src/main/kotlin/io/curity/oauthagent/CookieEncrypter.kt
@@ -150,6 +150,6 @@ class CookieEncrypter(private val config: OAuthAgentConfiguration, private val c
         const val GCM_TAG_SIZE = 16
         const val CURRENT_VERSION = 1
 
-        private val minusDayInSeconds = -Duration.ofDays(1).toSeconds().toInt()
+        private val minusDayInSeconds = -Duration.ofDays(1).seconds.toInt()
     }
 }

--- a/src/main/kotlin/io/curity/oauthagent/ExtraParams.kt
+++ b/src/main/kotlin/io/curity/oauthagent/ExtraParams.kt
@@ -1,0 +1,3 @@
+package io.curity.oauthagent
+
+data class ExtraParams(val key: String, val value: String)

--- a/src/main/kotlin/io/curity/oauthagent/StringHelper.kt
+++ b/src/main/kotlin/io/curity/oauthagent/StringHelper.kt
@@ -1,13 +1,13 @@
 package io.curity.oauthagent
 
 import java.net.URLEncoder
-import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 import java.util.Base64
 
 fun String.encodeURI(): String
 {
-    return URLEncoder.encode(this, Charset.forName("UTF-8"))
+    return URLEncoder.encode(this, StandardCharsets.UTF_8.name())
 }
 
 fun String.hash(): String

--- a/src/main/kotlin/io/curity/oauthagent/controller/LoginController.kt
+++ b/src/main/kotlin/io/curity/oauthagent/controller/LoginController.kt
@@ -1,6 +1,5 @@
 package io.curity.oauthagent.controller
 
-import java.util.Optional
 import io.curity.oauthagent.*
 import io.curity.oauthagent.exception.CookieDecryptionException
 import io.curity.oauthagent.exception.InvalidResponseJwtException
@@ -32,7 +31,7 @@ class LoginController(
     suspend fun startLogin(
         request: ServerHttpRequest,
         response: ServerHttpResponse,
-        @RequestBody(required = false) body: StartAuthorizationRequest?
+        @RequestBody(required = false) body: StartAuthorizationParameters?
     ): StartAuthorizationResponse
     {
         requestValidator.validateServletRequest(
@@ -118,12 +117,12 @@ class LoginController(
         )
     }
 
-    private suspend fun getAuthorizationURL(options: StartAuthorizationRequest?): AuthorizationRequestData
+    private suspend fun getAuthorizationURL(parameters: StartAuthorizationParameters?): AuthorizationRequestData
     {
         val codeVerifier = oAuthParametersProvider.getCodeVerifier()
         val state = oAuthParametersProvider.getState()
 
-        val authorizationRequestUrl = authorizationServerClient.getAuthorizationRequestObjectUri(state, codeVerifier, options)
+        val authorizationRequestUrl = authorizationServerClient.getAuthorizationRequestObjectUri(state, codeVerifier, parameters)
 
         return AuthorizationRequestData(
             authorizationRequestUrl,
@@ -165,8 +164,8 @@ class LoginController(
 
 data class OAuthQueryParams(val code: String?, val state: String?)
 
-class StartAuthorizationRequest(
-    val extraParams: ArrayList<ExtraParams>?
+class StartAuthorizationParameters(
+    val extraParams: List<ExtraParams>?
 )
 
 class StartAuthorizationResponse(

--- a/src/main/kotlin/io/curity/oauthagent/controller/LoginController.kt
+++ b/src/main/kotlin/io/curity/oauthagent/controller/LoginController.kt
@@ -1,15 +1,9 @@
 package io.curity.oauthagent.controller
 
-import io.curity.oauthagent.AuthorizationRequestData
-import io.curity.oauthagent.AuthorizationServerClient
-import io.curity.oauthagent.CookieEncrypter
-import io.curity.oauthagent.CookieName
-import io.curity.oauthagent.OAuthParametersProvider
-import io.curity.oauthagent.RequestValidator
-import io.curity.oauthagent.ValidateRequestOptions
+import java.util.Optional
+import io.curity.oauthagent.*
 import io.curity.oauthagent.exception.CookieDecryptionException
 import io.curity.oauthagent.exception.InvalidResponseJwtException
-import io.curity.oauthagent.generateRandomString
 import org.jose4j.jwt.consumer.InvalidJwtException
 import org.jose4j.jwt.consumer.JwtConsumer
 import org.springframework.http.HttpHeaders.SET_COOKIE
@@ -21,7 +15,6 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.util.UriComponentsBuilder
-
 
 @RestController
 @CrossOrigin
@@ -35,15 +28,19 @@ class LoginController(
     private val oAuthParametersProvider: OAuthParametersProvider
 )
 {
-    @PostMapping("/start")
-    suspend fun startLogin(request: ServerHttpRequest, response: ServerHttpResponse): StartAuthorizationResponse
+    @PostMapping("/start", consumes = ["application/json"])
+    suspend fun startLogin(
+        request: ServerHttpRequest,
+        response: ServerHttpResponse,
+        @RequestBody(required = false) body: StartAuthorizationRequest?
+    ): StartAuthorizationResponse
     {
         requestValidator.validateServletRequest(
             request,
             ValidateRequestOptions(requireCsrfHeader = false)
         )
 
-        val authorizationRequestData = getAuthorizationURL()
+        val authorizationRequestData = getAuthorizationURL(body)
 
         val encryptedCookieValue =
             cookieEncrypter.getEncryptedCookie(cookieName.tempLoginData, authorizationRequestData.toJSONString())
@@ -121,12 +118,12 @@ class LoginController(
         )
     }
 
-    private suspend fun getAuthorizationURL(): AuthorizationRequestData
+    private suspend fun getAuthorizationURL(options: StartAuthorizationRequest?): AuthorizationRequestData
     {
         val codeVerifier = oAuthParametersProvider.getCodeVerifier()
         val state = oAuthParametersProvider.getState()
 
-        val authorizationRequestUrl = authorizationServerClient.getAuthorizationRequestObjectUri(state, codeVerifier)
+        val authorizationRequestUrl = authorizationServerClient.getAuthorizationRequestObjectUri(state, codeVerifier, options)
 
         return AuthorizationRequestData(
             authorizationRequestUrl,
@@ -167,6 +164,10 @@ class LoginController(
 }
 
 data class OAuthQueryParams(val code: String?, val state: String?)
+
+class StartAuthorizationRequest(
+    val extraParams: ArrayList<ExtraParams>?
+)
 
 class StartAuthorizationResponse(
     val authorizationRequestUrl: String

--- a/src/test/groovy/io/curity/oauthagent/ExtensibilitySpec.groovy
+++ b/src/test/groovy/io/curity/oauthagent/ExtensibilitySpec.groovy
@@ -1,0 +1,76 @@
+package io.curity.oauthagent
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*
+import static groovy.json.JsonOutput.toJson
+import static org.springframework.http.HttpMethod.POST
+import static org.springframework.http.HttpStatus.*
+
+class ExtensibilitySpec extends TokenHandlerSpecification {
+
+    def "Starting a login request with a runtime OpenID Connect parameter succeeds"() {
+        given:
+
+        def options = [
+                "extraParams": [
+                        ["key": "prompt", "value": "login"]
+                ]
+        ]
+
+        def request = getRequestWithValidOrigin(POST, loginStartURI, toJson(options))
+        stubFor(post(stubs.getPAREndpointPath())
+            .willReturn(aResponse()
+                .withBody(toJson([request_uri: "parRequestURI", expires_in: 100]))
+                .withHeader("Content-Type", "application/json")
+                .withStatus(200)
+        ))
+
+        when:
+        def response = client.exchange(request, String.class)
+
+        then:
+        response.statusCode == OK
+        def responseBody = json.parseText(response.body)
+        def authorizationRequestUrl = responseBody["authorizationRequestUrl"]?.toString()
+        !authorizationRequestUrl.empty
+    }
+
+    def "Starting a login request with the OpenID Connect claims parameter succeeds"() {
+
+        def claims = [
+                "id_token": [
+                        "acr": [
+                                "essential": true,
+                                "values": [
+                                        "urn:se:curity:authentication:html-form:htmlform1"
+                                ]
+                        ],
+                        "my_custom_claim": [
+                                "essential": true,
+                        ]
+                ]
+        ]
+
+        def options = [
+                "extraParams": [
+                        ["key": "claims", "value": toJson(claims)]
+                ]
+        ]
+
+        def request = getRequestWithValidOrigin(POST, loginStartURI, toJson(options))
+        stubFor(post(stubs.getPAREndpointPath())
+                .willReturn(aResponse()
+                        .withBody(toJson([request_uri: "parRequestURI", expires_in: 100]))
+                        .withHeader("Content-Type", "application/json")
+                        .withStatus(200)
+                ))
+
+        when:
+        def response = client.exchange(request, String.class)
+
+        then:
+        response.statusCode == OK
+        def responseBody = json.parseText(response.body)
+        def authorizationRequestUrl = responseBody["authorizationRequestUrl"]?.toString()
+        !authorizationRequestUrl.empty
+    }
+}

--- a/src/test/groovy/io/curity/oauthagent/ExtensibilitySpec.groovy
+++ b/src/test/groovy/io/curity/oauthagent/ExtensibilitySpec.groovy
@@ -7,7 +7,7 @@ import static org.springframework.http.HttpStatus.*
 
 class ExtensibilitySpec extends TokenHandlerSpecification {
 
-    def "Starting a login request with a runtime OpenID Connect parameter succeeds"() {
+    def "Starting a login request with a simple OpenID Connect parameter should succeed"() {
         given:
 
         def options = [
@@ -34,7 +34,7 @@ class ExtensibilitySpec extends TokenHandlerSpecification {
         !authorizationRequestUrl.empty
     }
 
-    def "Starting a login request with the OpenID Connect claims parameter succeeds"() {
+    def "Starting a login request with multiple OpenID Connect parameters should succeed"() {
 
         def claims = [
                 "id_token": [
@@ -43,15 +43,13 @@ class ExtensibilitySpec extends TokenHandlerSpecification {
                                 "values": [
                                         "urn:se:curity:authentication:html-form:htmlform1"
                                 ]
-                        ],
-                        "my_custom_claim": [
-                                "essential": true,
                         ]
                 ]
         ]
 
         def options = [
                 "extraParams": [
+                        ["key": "ui_locates", "value": "fr"],
                         ["key": "claims", "value": toJson(claims)]
                 ]
         ]

--- a/src/test/groovy/io/curity/oauthagent/ExtensibilitySpec.groovy
+++ b/src/test/groovy/io/curity/oauthagent/ExtensibilitySpec.groovy
@@ -18,7 +18,8 @@ class ExtensibilitySpec extends TokenHandlerSpecification {
 
         def request = getRequestWithValidOrigin(POST, loginStartURI, toJson(options))
         stubFor(post(stubs.getPAREndpointPath())
-            .willReturn(aResponse()
+                .withRequestBody(containing("prompt=login"))
+                .willReturn(aResponse()
                 .withBody(toJson([request_uri: "parRequestURI", expires_in: 100]))
                 .withHeader("Content-Type", "application/json")
                 .withStatus(200)
@@ -46,16 +47,19 @@ class ExtensibilitySpec extends TokenHandlerSpecification {
                         ]
                 ]
         ]
+        def claimsJson = toJson(claims)
 
         def options = [
                 "extraParams": [
-                        ["key": "ui_locates", "value": "fr"],
-                        ["key": "claims", "value": toJson(claims)]
+                        ["key": "ui_locales", "value": "fr"],
+                        ["key": "claims", "value": claimsJson]
                 ]
         ]
 
         def request = getRequestWithValidOrigin(POST, loginStartURI, toJson(options))
         stubFor(post(stubs.getPAREndpointPath())
+                .withRequestBody(containing("ui_locales=fr"))
+                .withRequestBody(containing("claims=$claimsJson"))
                 .willReturn(aResponse()
                         .withBody(toJson([request_uri: "parRequestURI", expires_in: 100]))
                         .withHeader("Content-Type", "application/json")


### PR DESCRIPTION
Ensure that customers can use common additional options with the token handler pattern:

- Parameters such as prompt / max_age / acr_values / claims

I have done this as a clientOptions object that contains a dictionary of key / value pairs, where both must be strings.
I think this is easiest to reason about and we could potentially use it for other endpoints in future.

Also updated to a yellow badge since we have good testing for this component.
I will add a v1.1.0 tag to this release also, with some notes on changes, and we should do this from now on.