### PR TITLE
Fixed verbose Java 17 build warnings about incremental compilation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,7 @@ tasks.withType<KotlinCompile> {
 	kotlinOptions {
 		freeCompilerArgs = listOf("-Xjsr305=strict")
 		jvmTarget = "11"
+		incremental = false
 	}
 }
 


### PR DESCRIPTION
After upgrading my local development Java version to Java 17 I was getting warnings from here building this project:
https://youtrack.jetbrains.com/issue/KT-47152

So I've disabled incremental compilation, since this is a small code base.
Maybe have a quick test yourself with both your current Java version and 17 and see if all is good.