### PR TITLE
Support CORS_ENABLED environment variable

### DIFF
--- a/src/main/kotlin/io/curity/oauthagent/OAuthAgentApplication.kt
+++ b/src/main/kotlin/io/curity/oauthagent/OAuthAgentApplication.kt
@@ -8,6 +8,7 @@ import org.jose4j.jwt.consumer.JwtConsumer
 import org.jose4j.jwt.consumer.JwtConsumerBuilder
 import org.jose4j.keys.resolvers.HttpsJwksVerificationKeyResolver
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.runApplication
 import org.springframework.context.annotation.Bean
 import org.springframework.web.cors.CorsConfiguration
@@ -18,6 +19,7 @@ import org.springframework.web.cors.reactive.CorsWebFilter
 class OAuthAgentApplication {
 
     @Bean
+    @ConditionalOnProperty(value = ["CORS_ENABLED"], havingValue = "true", matchIfMissing = true)
     fun corsWebFilter(configuration: OAuthAgentConfiguration): CorsWebFilter {
 
         val source = UrlBasedCorsConfigurationSource()

--- a/src/main/kotlin/io/curity/oauthagent/OAuthAgentConfiguration.kt
+++ b/src/main/kotlin/io/curity/oauthagent/OAuthAgentConfiguration.kt
@@ -31,6 +31,7 @@ data class OAuthAgentConfigurationProperties(
     var cookieNamePrefix: String,
     var encKey: String,
     var trustedWebOrigins: List<String>,
+    var corsEnabled: Boolean,
     var cookieSerializeOptions: CookieSerializeOptions
 )
 
@@ -69,5 +70,6 @@ class OAuthAgentConfiguration(configurationProperties: OAuthAgentConfigurationPr
     val cookieNamePrefix = configurationProperties.cookieNamePrefix
     val encKey = configurationProperties.encKey
     val trustedWebOrigins = configurationProperties.trustedWebOrigins
+    val corsEnabled = configurationProperties.corsEnabled
     val cookieSerializeOptions = configurationProperties.cookieSerializeOptions
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,7 @@ oauthagent:
 
   trustedWebOrigins:
   - ${TRUSTED_WEB_ORIGIN:https://www.example.local}
+  corsEnabled: ${CORS_ENABLED:true}
   issuer: ${ISSUER:https://login.example.local:8443/oauth/v2/oauth-anonymous}
   jwksUri: ${JWKS_URI:https://login.example.local:8443/oauth/v2/oauth-anonymous/jwks}
   authorizeEndpoint: ${AUTHORIZE_ENDPOINT:https://login.example.local:8443/oauth/v2/oauth-authorize}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -16,6 +16,7 @@ oauthagent:
 
   trustedWebOrigins:
   - https://www.example.com
+  corsEnabled: false
   issuer: https://login.example.com/oauth
   jwksUri: https://localhost:8443/oauth/jwks
   authorizeEndpoint: https://localhost:8443/oauth/authorize


### PR DESCRIPTION
In a same domain setup like this, there should be an option for the OAuth Agent to avoid writing any CORS response headers.

Web Static Content: https://www.example.com
Token Handler: https://www.example.com/api

It should also not validate the origin header on GET requests, since it will not be sent by the browser. For POST requests we continue to do so, as a CSRF protection recommended by OWASP.